### PR TITLE
Add more texture units

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1208,6 +1208,11 @@ pub const TextureUnit = enum(Enum) {
     texture_0 = c.GL_TEXTURE0,
     texture_1 = c.GL_TEXTURE1,
     texture_2 = c.GL_TEXTURE2,
+    texture_3 = c.GL_TEXTURE3,
+    texture_4 = c.GL_TEXTURE4,
+    texture_5 = c.GL_TEXTURE5,
+    texture_6 = c.GL_TEXTURE6,
+    texture_7 = c.GL_TEXTURE7,
 };
 
 pub const TextureParameter = enum(Enum) {


### PR DESCRIPTION
In OpenGL ES 2, 8 texture units are guaranteed so that feels like a good number to stop at. 3 hasn't been enough for my project.