### PR TITLE
Make TextureUnit non-exhaustive + add TextureUnit.unit

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1441,6 +1441,11 @@ pub const TextureUnit = enum(types.Enum) {
     texture_5 = c.GL_TEXTURE5,
     texture_6 = c.GL_TEXTURE6,
     texture_7 = c.GL_TEXTURE7,
+    _,
+
+    pub fn unit(id: types.Enum) TextureUnit {
+        return @intToEnum(TextureUnit, @enumToInt(TextureUnit.texture_0) + id);
+    }
 };
 
 pub const TextureParameter = enum(types.Enum) {


### PR DESCRIPTION
TextureUnit is now non-exhaustive which allows one to specify other
texture units than the ones defined. Additionally, this commit adds the
TextureUnit.unit function which allows one to generate these texture
units easily.

Closes #54 