### PR TITLE
Add ability to use custom gl namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ var vertex_buffer = gl.Buffer.create();
 defer vertex_buffer.delete();
 ```
 
+You may also use a different OpenGL Loading Library by declaring a public `gl` namespace on your `root` file.
+
 ## Development Philosophy
 
 This library is developed incrementally. That means that functions and other things will be included on-demand and not just for the sake of completeness.

--- a/zgl.zig
+++ b/zgl.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
+const root = @import("root");
 
-const c = @cImport({
-    @cInclude("epoxy/gl.h");
-});
+const c = if (@hasDecl(root, "gl"))
+    root.gl
+else
+    @cImport({
+        @cInclude("epoxy/gl.h");
+    });
 
 comptime {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
Uses `root.gl` if it's defined, and if not fallback to `epoxy/gl.h`. Also added a note about this change to the `README`. This opens the possibility of using something like `glad` instead of `libepoxy` if the user of the library chooses to.