### PR TITLE
Fix customizable gl namespace

### DIFF
--- a/c.zig
+++ b/c.zig
@@ -1,0 +1,8 @@
+const root = @import("root");
+
+pub usingnamespace if (@hasDecl(root, "gl"))
+    root.gl
+else
+    @cImport({
+        @cInclude("epoxy/gl.h");
+    });

--- a/types.zig
+++ b/types.zig
@@ -1,6 +1,4 @@
-const c = @cImport({
-    @cInclude("epoxy/gl.h");
-});
+const c = @import("c.zig");
 
 const gl = @import("zgl.zig");
 

--- a/zgl.zig
+++ b/zgl.zig
@@ -1,12 +1,6 @@
 const std = @import("std");
-const root = @import("root");
 
-const c = if (@hasDecl(root, "gl"))
-    root.gl
-else
-    @cImport({
-        @cInclude("epoxy/gl.h");
-    });
+const c = @import("c.zig");
 
 comptime {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
Oops, I didn't realize when making #59 that there was a separate `@cImport` for `libepoxy` in `types.zig`. This PR fixes it so the same namespace is used in both files.