### PR TITLE
Allow loadExtensions to return an error

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -2358,7 +2358,7 @@ pub fn hasExtension(extension: [:0]const u8) bool {
     return false;
 }
 
-pub fn loadExtensions(load_ctx: anytype, get_proc_address: fn(@TypeOf(load_ctx), [:0]const u8) ?binding.FunctionPointer) void {
+pub fn loadExtensions(load_ctx: anytype, get_proc_address: fn(@TypeOf(load_ctx), [:0]const u8) ?binding.FunctionPointer) !void {
     return binding.load( load_ctx, get_proc_address );
 }
 


### PR DESCRIPTION
`binding.load` can return an error but `loadExtensions` does not do anything to handle the error, this corrects that.