### PR TITLE
implements cw & ccw face call

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1346,6 +1346,16 @@ pub fn depthFunc(func: DepthFunc) void {
     checkError();
 }
 
+pub const Face = enum(types.Enum) {
+    cw = binding.CW,
+    ccw = binding.CCW,
+};
+
+pub fn frontFace(mode: Face) void {
+    binding.frontFace(@enumToInt(mode));
+    checkError();
+}
+
 pub fn stencilMask(mask: u32) void {
     binding.stencilMask(mask);
     checkError();


### PR DESCRIPTION
Adds glFrontface (vertex winding order). While not actually necessary due to cullface, it's nice to have.