### PR TITLE
Remove alignment specifier on namedBufferData.

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -582,8 +582,7 @@ pub const BufferUsage = enum(types.Enum) {
     dynamic_copy = binding.DYNAMIC_COPY,
 };
 
-// using align(1) as we are not required to have aligned data here
-pub fn namedBufferData(buf: types.Buffer, comptime T: type, items: []align(1) const T, usage: BufferUsage) void {
+pub fn namedBufferData(buf: types.Buffer, comptime T: type, items: []const T, usage: BufferUsage) void {
     binding.namedBufferData(
         @enumToInt(buf),
         cs2gl(@sizeOf(T) * items.len),


### PR DESCRIPTION
The requirement of items being 1 byte aligned in namedBufferData prevents usage of types that have higher alignment. Lets remove that requirement since its not one enforced by OpenGL. https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferData.xhtml