### PR TITLE
Replace BufferMapTarget with BufferTarget

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1783,6 +1783,23 @@ pub const TextureInternalFormat = enum(types.Enum) {
     depth_component16 = binding.DEPTH_COMPONENT16,
 };
 
+pub fn texStorage2D(
+    target: TextureTarget,
+    levels: usize,
+    internalformat: TextureInternalFormat,
+    width: usize,
+    height: usize,
+) void {
+    binding.texStorage2D(
+        @enumToInt(target),
+        @intCast(types.SizeI, levels),
+        @enumToInt(internalformat),
+        @intCast(types.SizeI, width),
+        @intCast(types.SizeI, height),
+    );
+    checkError();
+}
+
 pub fn textureStorage2D(
     texture: types.Texture,
     levels: usize,
@@ -1796,6 +1813,25 @@ pub fn textureStorage2D(
         @enumToInt(internalformat),
         @intCast(types.SizeI, width),
         @intCast(types.SizeI, height),
+    );
+    checkError();
+}
+
+pub fn texStorage3D(
+    target: TextureTarget,
+    levels: usize,
+    internalformat: TextureInternalFormat,
+    width: usize,
+    height: usize,
+    depth: usize
+) void {
+    binding.texStorage3D(
+        @enumToInt(target),
+        @intCast(types.SizeI, levels),
+        @enumToInt(internalformat),
+        @intCast(types.SizeI, width),
+        @intCast(types.SizeI, height),
+        @intCast(types.SizeI, depth)
     );
     checkError();
 }

--- a/zgl.zig
+++ b/zgl.zig
@@ -683,23 +683,6 @@ pub fn namedBufferStorage(buf: types.Buffer, comptime T: type, count: usize, ite
     checkError();
 }
 
-pub const BufferMapTarget = enum(types.Enum) {
-    array_buffer = binding.ARRAY_BUFFER,
-    atomic_counter_buffer = binding.ATOMIC_COUNTER_BUFFER,
-    copy_read_buffer = binding.COPY_READ_BUFFER,
-    copy_write_buffer = binding.COPY_WRITE_BUFFER,
-    dispatch_indirect_buffer = binding.DISPATCH_INDIRECT_BUFFER,
-    draw_indirect_buffer = binding.DRAW_INDIRECT_BUFFER,
-    element_array_buffer = binding.ELEMENT_ARRAY_BUFFER,
-    pixel_pack_buffer = binding.PIXEL_PACK_BUFFER,
-    pixel_unpack_buffer = binding.PIXEL_UNPACK_BUFFER,
-    query_buffer = binding.QUERY_BUFFER,
-    shader_storage_buffer = binding.SHADER_STORAGE_BUFFER,
-    texture_buffer = binding.TEXTURE_BUFFER,
-    transform_feedback_buffer = binding.TRANSFORM_FEEDBACK_BUFFER,
-    uniform_buffer = binding.UNIFORM_BUFFER,
-};
-
 pub const BufferMapAccess = enum(types.Enum) {
     read_only = binding.READ_ONLY,
     write_only = binding.WRITE_ONLY,
@@ -707,7 +690,7 @@ pub const BufferMapAccess = enum(types.Enum) {
 };
 
 pub fn mapBuffer(
-    target: BufferMapTarget,
+    target: BufferTarget,
     comptime T: type,
     access: BufferMapAccess,
 ) [*]align(1) T {
@@ -720,7 +703,7 @@ pub fn mapBuffer(
     return @as([*]align(1) T, @ptrCast(ptr));
 }
 
-pub fn unmapBuffer(target: BufferMapTarget) bool {
+pub fn unmapBuffer(target: BufferTarget) bool {
     const ok = binding.unmapBuffer(@intFromEnum(target));
     checkError();
     return ok == binding.TRUE;


### PR DESCRIPTION
This is a fix for https://github.com/ziglibs/zgl/issues/83. This removes `BufferMapTarget` and replaces all instances of it with `BufferTarget`.