### PR TITLE
change type of readPixel data pointer

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -276,7 +276,7 @@ pub fn readPixels(
     height: usize,
     format: PixelFormat,
     pixel_type: PixelType,
-    data: *anyopaque,
+    data: ?[*]u8,
 ) void {
     binding.readPixels(
         @as(types.Int, @intCast(x)),


### PR DESCRIPTION
1. It should be nullable, as it could be used for pixel buffer operations.
2. No other procedure uses plain `*anyopaque`, byte array pointer makes more sense here, imo.

Not sure whether it will break any existing code, alternatively `?*anyopaque` could be used if it does.
