### PR TITLE
Allow access to the raw bindings

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const binding = @import("binding.zig");
+pub const binding = @import("binding.zig");
 
 comptime {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
Allows the user of this library to access the raw bindings if necessary:

```zig
gl.bindings.xxxYyyZzz(...)
```