### PR TITLE
update zig: std.meta.globalOption removed

### DIFF
--- a/zgl.zig
+++ b/zgl.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const root = @import("root");
 pub const binding = @import("binding.zig");
 
 comptime {
@@ -19,9 +20,12 @@ pub const ErrorHandling = enum {
     none,
 };
 
-const error_handling: ErrorHandling =
-    std.meta.globalOption("opengl_error_handling", ErrorHandling) orelse
-    if (std.debug.runtime_safety) .assert else .none;
+const error_handling: ErrorHandling = if (@hasDecl(root, "opengl_error_handling"))
+    root.opengl_error_handling
+else if (std.debug.runtime_safety)
+    .assert
+else
+    .none;
 
 /// Checks if a OpenGL error happend and may yield it.
 /// This function is configurable via `opengl_error_handling` in the root file.


### PR DESCRIPTION
Keep the convention for the time being, but reimplement without `std` function.